### PR TITLE
Ensure it works with spring-boot 1.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,11 +8,21 @@
     <artifactId>spring-boot-demo</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>1.2.2.RELEASE</version>
+    </parent>
+
+	<properties>
+		<activiti.version>5.17.0</activiti.version>
+	</properties>
+
     <dependencies>
         <dependency>
             <groupId>org.activiti</groupId>
             <artifactId>spring-boot-starter-basic</artifactId>
-            <version>5.17.0</version>
+            <version>${activiti.version}</version>
         </dependency>
         <!--<dependency>-->
             <!--<groupId>com.h2database</groupId>-->
@@ -32,14 +42,28 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>1.1.6.RELEASE</version>
+            <version>${spring-boot.version}</version>
         </dependency>
         <dependency>
             <groupId>org.activiti</groupId>
             <artifactId>spring-boot-starter-jpa</artifactId>
-            <version>5.17.0</version>
+            <version>${activiti.version}</version>
         </dependency>
+        <!-- REST service API needed -->
+        <dependency>
+            <groupId>org.activiti</groupId>
+            <artifactId>activiti-rest</artifactId>
+            <version>${activiti.version}</version>
+        </dependency>        
     </dependencies>
-
-
+    
+    <build>
+        <plugins>
+            <!-- makes spring-boot:run goal available -->
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>    
 </project>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,7 @@
 spring.jpa.hibernate.ddl-auto=update
+
+# This way spring boot will scan for an unused port
+server.port=8080
+
+# Force this password for user "user" instead of a generated one
+security.user.password=foo


### PR DESCRIPTION
Added spring-boot maven plugin, this way you can issue mvn spring-boot:run to start application from command line.

Added dependency for Activiti REST service API. Didn't run without it. REST service works without doing anything else. This URL just works: http://localhost:8080/repository/process-definitions

Left two new properties inside application.properties: server.port and security.user.password. In my case http default port (8080) was already used in my machine. And the generated password gets lost with all those springframework log messages.
